### PR TITLE
Remove bad ig_leader

### DIFF
--- a/common/history/characters/ica - ican.txt
+++ b/common/history/characters/ica - ican.txt
@@ -5,7 +5,6 @@
 			last_name = "Gulzarob"
 			historical = yes
 			ruler = yes
-			ig_leader = yes
 			is_general = yes
 			age = 48
 			female = yes

--- a/common/history/characters/str - sternenwacht.txt
+++ b/common/history/characters/str - sternenwacht.txt
@@ -5,7 +5,6 @@
 			last_name = "Conrad"
 			historical = yes
 			ruler = yes
-			ig_leader = yes
 			is_general = yes
 			age = 21
 			interest_group = ig_landowners


### PR DESCRIPTION
Ican and Sternewacht have transfer_of_power settings which do not allow for the ruler to be an IG leader