### PR TITLE
Naga Population Tweaks and Ceraun start fine tuning

### DIFF
--- a/common/history/buildings/01_settler_coast.txt
+++ b/common/history/buildings/01_settler_coast.txt
@@ -651,7 +651,7 @@
                 add_ownership={ 
                     building={ 
                         type="building_financial_district"
-                        country="c:THE_CHASM"
+                        country="c:CER"
                         levels=2
                         region="STATE_THE_CHASM"
                    }

--- a/common/history/buildings/01_settler_coast.txt
+++ b/common/history/buildings/01_settler_coast.txt
@@ -646,6 +646,19 @@
 
   s:STATE_THE_CHASM = {
 	region_state:CER={
+            create_building={
+			building="building_chemical_plants"
+                add_ownership={ 
+                    building={ 
+                        type="building_financial_district"
+                        country="c:THE_CHASM"
+                        levels=2
+                        region="STATE_THE_CHASM"
+                   }
+                }
+			reserves=1
+			activate_production_methods={ "pm_artificial_fertilizers" }
+		}
         create_building={
 			building="building_steel_mills"
                 add_ownership={ 
@@ -3127,9 +3140,9 @@
                 add_ownership={ 
                     building={ 
                         type="building_financial_district"
-                        country="c:EME"
+                        country="c:ARR"
                         levels=2
-                        region="STATE_SHARINDLARS_NEEDLE"
+                        region="STATE_GREENCOURT"
                    }
                 }
 			reserves=1

--- a/common/history/buildings/01_settler_coast.txt
+++ b/common/history/buildings/01_settler_coast.txt
@@ -646,7 +646,7 @@
 
   s:STATE_THE_CHASM = {
 	region_state:CER={
-            create_building={
+        create_building={
 			building="building_chemical_plants"
                 add_ownership={ 
                     building={ 
@@ -789,6 +789,19 @@
 				}
 			reserves=1
 			activate_production_methods={ "pm_open_air_stockyards" "pm_simple_ranch" "pm_standard_fences" "pm_unrefrigerated"  }
+		}
+		create_building={
+			building="building_railway"
+				add_ownership={ 
+					building={ 
+						type="building_financial_district"
+						country="c:CER"
+						levels=2
+						region="STATE_THE_CHASM"
+					}
+				}
+			reserves=1
+			activate_production_methods={ "pm_steam_trains" "pm_wooden_passenger_carriages" }
 		}
 	}
   }	
@@ -5640,6 +5653,19 @@
 
   s:STATE_FERNSEA = {
 	region_state:CER={
+		create_building={
+			building="building_railway"
+				add_ownership={ 
+					building={ 
+						type="building_financial_district"
+						country="c:CER"
+						levels=1
+						region="STATE_FERNSEA"
+					}
+				}
+			reserves=1
+			activate_production_methods={ "pm_steam_trains" "pm_wooden_passenger_carriages" }
+		}
 		create_building={
 			building="building_government_administration"
 			level=13

--- a/common/history/buildings/03_bay_of_new_fortune.txt
+++ b/common/history/buildings/03_bay_of_new_fortune.txt
@@ -556,7 +556,7 @@
 						type="building_financial_district"
 						country="c:YKU"
 						levels=1
-						region=STATE_ANTAQAQA"
+						region="STATE_ANTAQAQA"
 					}
 				}
 				reserves=1

--- a/common/history/pops/05_locari.txt
+++ b/common/history/pops/05_locari.txt
@@ -21,7 +21,7 @@
 		region_state:GDY = {
 			create_pop = {
 				culture = jungle_naga
-				size = 6634412
+				size = 2948484
 			}
 			create_pop = {
 				culture = jungle_naga
@@ -31,7 +31,7 @@
 			create_pop = {
 				pop_type = slaves
 				culture = jungle_naga
-				size = 110000
+				size = 500404
 			}
 			create_pop = {
 				pop_type = slaves
@@ -152,21 +152,21 @@
 		region_state:VIP = {
 			create_pop = {
 				culture = jungle_naga
-				size = 12479910
+				size = 1984030
 			}
 			create_pop = {
 				culture = gulf_naga
-				size = 871981
+				size = 2947389
 			}
 			create_pop = {
 				culture = gulf_naga
 				religion = animist
-				size = 565099
+				size = 1875638
 			}
 			create_pop = {
 				culture = jungle_naga
 				religion = animist
-				size = 109374
+				size = 520483
 			}
 			create_pop = {
 				pop_type = slaves
@@ -284,15 +284,15 @@
 		region_state:SAP = {
 			create_pop = {
 				culture = gulf_naga
-				size = 6724685
+				size = 3476737
 			}
 			create_pop = {
 				culture = jungle_naga
-				size = 951351
+				size = 3874739
 			}
 			create_pop = {
 				culture = awakened
-				size = 1164904
+				size = 4938383
 			}
 			create_pop = {
 				pop_type = slaves
@@ -373,12 +373,12 @@
 		region_state:JIV = {
 			create_pop = {
 				culture = gulf_naga
-				size = 9712168
+				size = 3348203
 			}
 			create_pop = {
 				culture = gulf_naga
 				religion = animist
-				size = 326095
+				size = 1394938
 			}
 			create_pop = {
 				pop_type = slaves
@@ -397,12 +397,12 @@
 		region_state:BHR = {
 			create_pop = {
 				culture = gulf_naga
-				size = 10312854
+				size = 4678949
 			}
 			create_pop = {
 				culture = gulf_naga
 				religion = animist
-				size = 2032854
+				size = 1038492
 			}
 			create_pop = {
 				pop_type = slaves
@@ -480,21 +480,21 @@
 		region_state:VIP = {
 			create_pop = {
 				culture = gulf_naga
-				size = 9370101
+				size = 3030493
 			}
 			create_pop = {
 				culture = gulf_naga
 				religion = animist
-				size = 109096
+				size = 500340
 			}
 			create_pop = {
 				culture = jungle_naga
-				size = 6602700
+				size = 2938403
 			}
 			create_pop = {
 				pop_type = slaves
 				culture = awakened
-				size = 200310
+				size = 1373948
 			}
 			create_pop = {
 				pop_type = slaves


### PR DESCRIPTION
Tweaked the starting population of the Naga states to be less ridiculously high (there are still about 20 million Naga in the world which to me feels reasonable for a race that only lives on one continent). Cerauns starting economy is now much more functional however they do still start with some resource deficits, decided to leave it that way to reflect that they were never meant to be independent so their economy wasnt built to be self-sufficient