### PR TITLE
AI Revisions - Ravik/Thaloria & Fix Default Strategy

### DIFF
--- a/common/ai_strategies/00_default_strategy.txt
+++ b/common/ai_strategies/00_default_strategy.txt
@@ -1187,7 +1187,7 @@ ai_strategy_default = {
 
 		add = {
 			value = investment_pool_income
-			divide = 500 # 1 construction output per this much into the investment pool				
+			divide = 800 # 1 construction output per this much into the investment pool				
 		}
 		
 		add = {
@@ -1205,10 +1205,14 @@ ai_strategy_default = {
 		}
 
 		add = {
-			value = 0
-			add = income
-			subtract = expenses
-			divide = 500
+			value = income
+			divide = 600
+			min = 0
+		}
+
+		subtract = {
+			value = expenses
+			divide = 600
 			min = 0
 		}
 		

--- a/common/ai_strategies/00_default_strategy.txt
+++ b/common/ai_strategies/00_default_strategy.txt
@@ -79,6 +79,24 @@ ai_strategy_default = {
 	# Using this value in other strategies will function additively
 	diplomatic_play_boldness = {
 		value = 50
+		
+		if = { #RAV will never give up agaisnt Thaloria
+			limit = {
+				c:RAV ?= this
+				exists = c:TLE
+				is_diplomatic_play_enemy_of = c:TLE
+			}
+			add = 1000
+		}
+
+		if = { #vice versa
+			limit = {
+				c:TLE ?= this
+				exists = c:RAV
+				is_diplomatic_play_enemy_of = c:RAV
+			}
+			add = 1000
+		}
 	} 
 		
 	# How many maneuvers are we OK with using up in the initial phase to add more wargoals

--- a/common/diplomatic_plays/00_diplomatic_plays.txt
+++ b/common/diplomatic_plays/00_diplomatic_plays.txt
@@ -1432,7 +1432,19 @@ dp_thalorian_crusade = {
 
 	allow_negotiated_peace = no
 	
-	on_weekly_pulse = {}
+	on_weekly_pulse = {
+		war = {
+			add_war_war_support = {
+				target = c:RAV
+				value = 1
+			}
+	
+			add_war_war_support = {
+				target = c:TLE
+				value = 1
+			}
+		}
+	}
 	
 	on_war_begins = {}
 

--- a/common/script_values/war_exhaustion_values.txt
+++ b/common/script_values/war_exhaustion_values.txt
@@ -1,0 +1,170 @@
+﻿# root = country
+# scope:war = the war we're evaluating war exhaustion for
+# No randomness is allowed in this script value
+
+war_exhaustion_from_enemy_contested_wargoals = {
+	add = define:NWar|WAR_EXHAUSTION_CONTESTED_ENEMY_WARGOALS
+	multiply = "enemy_contested_wargoals(scope:war)"
+
+}
+
+military_size = {
+	add = army_size_including_conscripts
+	add = navy_size
+}
+
+war_exhaustion_from_casualties = {
+	add = "scope:war.num_country_casualties(root)"
+	if = {
+		limit = { military_size > 0 }
+		divide = military_size
+	}
+	divide = 1000
+	multiply = define:NWar|WAR_EXHAUSTION_KIA_FACTOR
+	multiply = {
+		add = define:NWar|WAR_EXHAUSTION_KIA_BASE_MULTIPLIER
+		add = {
+			add = "size_weighted_lost_battles_fraction(scope:war)"
+			multiply = define:NWar|WAR_EXHAUSTION_KIA_BATTLES_LOST_MULTIPLIER
+		}
+	}
+}
+
+war_exhaustion_from_lobby_clout = {
+	add = "lobby_war_opposition(scope:war)"
+	multiply = define:NWar|WAR_EXHAUSTION_ANTI_WAR_LOBBY_CLOUT_FACTOR
+}
+
+war_support_from_lobby_clout = {
+	add = "lobby_war_support(scope:war)"
+	multiply = define:NWar|WAR_EXHAUSTION_PRO_WAR_LOBBY_CLOUT_FACTOR
+}
+
+war_exhaustion_from_country_turmoil = {
+	add = country_turmoil
+	multiply = define:NWar|WAR_EXHAUSTION_TURMOIL_FACTOR
+}
+
+war_exhaustion = {
+	add = {
+		add = define:NWar|WAR_EXHAUSTION_BASE
+		desc = "WAR_EXHAUSTION_BASE"
+	}
+	
+	add = {
+		if = {
+			limit = {
+				enemy_occupation <= 0.0
+			}
+			add = {
+				add = 0.0
+				desc = "WAR_EXHAUSTION_FROM_ENEMY_OCCUPATION_NONE"
+			}
+		}
+		else_if = {
+			limit = {
+				enemy_occupation < 0.1
+			}
+			add = {
+				add = 0.1
+				desc = "WAR_EXHAUSTION_FROM_ENEMY_OCCUPATION_LOW"
+			}
+		}
+		else_if = {
+			limit = {
+				enemy_occupation < 0.25
+			}
+			add = {
+				add = 0.5
+				desc = "WAR_EXHAUSTION_FROM_ENEMY_OCCUPATION_MODERATE"
+			}
+		}
+		else_if = {
+			limit = {
+				enemy_occupation < 0.5
+			}
+			add = {
+				add = 1.0
+				desc = "WAR_EXHAUSTION_FROM_ENEMY_OCCUPATION_SUBSTANTIAL"
+			}
+		}
+		else_if = {
+			limit = {
+				enemy_occupation < 0.75
+			}
+			add = {
+				add = 2.0
+				desc = "WAR_EXHAUSTION_FROM_ENEMY_OCCUPATION_HIGH"
+			}
+		}
+		else_if = {
+			limit = {
+				enemy_occupation < 0.9
+			}
+			add = {
+				add = 3.0
+				desc = "WAR_EXHAUSTION_FROM_ENEMY_OCCUPATION_EXTREME"
+			}
+		}
+		else_if = {
+			limit = {
+				enemy_occupation <= 1.0
+			}
+			add = {
+				add = 10.0
+				desc = "WAR_EXHAUSTION_FROM_ENEMY_OCCUPATION_TOTAL"
+			}
+		}
+	}
+
+	if = {
+		limit = { war_exhaustion_from_enemy_contested_wargoals >= 0.01 }
+		add = {
+			add = war_exhaustion_from_enemy_contested_wargoals
+			desc = "WAR_EXHAUSTION_FROM_ENEMY_CONTESTED_WARGOALS"
+		}
+	}
+	
+	if = {
+		limit = { war_exhaustion_from_casualties >= 0.01 }
+		add = {
+			add = war_exhaustion_from_casualties
+			desc = "WAR_EXHAUSTION_FROM_CASUALTIES"
+			multiply = {
+				add = 1
+				add = modifier:country_war_exhaustion_casualties_mult
+				min = 0
+				desc = "WAR_EXHAUSTION_FROM_country_war_exhaustion_casualties_mult"
+			}
+		}
+	}
+	
+	if = {
+		limit = { war_exhaustion_from_country_turmoil >= 0.01 }
+		add = {
+			add = war_exhaustion_from_country_turmoil
+			desc = "WAR_EXHAUSTION_FROM_TURMOIL"
+		}
+	}	
+	
+	if = {
+		limit = { war_exhaustion_from_lobby_clout >= 0.01 }
+		add = {
+			add = war_exhaustion_from_lobby_clout
+			desc = "WAR_OPPOSITION_FROM_LOBBIES"
+		}
+	}	
+	
+	if = {
+		limit = { war_support_from_lobby_clout <= -0.01 }
+		add = {
+			add = war_support_from_lobby_clout
+			desc = "WAR_SUPPORT_FROM_LOBBIES"
+		}
+	}		
+	
+	add = {
+		add = "additional_war_exhaustion(scope:war.diplomatic_play)"
+		desc = "WAR_EXHAUSTION_FROM_EVENTS"
+	}
+}


### PR DESCRIPTION
- Change to strategy to make Ravik and Thaloria never back down in diplomatic plays agaisnt eachother
- In the initial crusader, Ravik and Thaloria will be way less likely to capitulate through gaining ticking war support (pretty much the only/best way to do it, minimal performance impact since it's scoped to the war)
- Fix some math that doesn't work in the default ai strategy so they build properly
- Reduce AI spending from investment because of that